### PR TITLE
upgrade bitgojs version to 4.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgod",
-  "version": "4.4.4",
+  "version": "4.17.0",
   "description": "BitGo API proxy conforming to bitcoind JSON-RPC API",
   "main": "src/index.js",
   "bin": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "argparse": "0.1.16",
     "assert": "0.4.9",
-    "bitgo": "4.4.1",
+    "bitgo": "4.17.0",
     "ini": "1.3.2",
     "json-rpc2": "git://github.com/BitGo/node-jsonrpc2.git#httpsRPCServer",
     "lodash": "2.4.1",


### PR DESCRIPTION
Almost all of the changes between v4.4.1 and v4.17.0 pertain to v2, which bitgod doesn't use so I think this is a low risk upgrade. The biggest thing I see is Arik's refactor of the unspent listing functions into a single unified function (https://phabricator.bitgo.com/D7183), which nobody has complained about so I think we're fine.