### PR TITLE
convert minUnspentSize to number in handleListUnspent

### DIFF
--- a/src/bitgod.js
+++ b/src/bitgod.js
@@ -746,6 +746,7 @@ BitGoD.prototype.handleListUnspent = function(minConfirms, maxConfirms, addresse
   var self = this;
   minConfirms = this.getNumber(minConfirms, 1);
   maxConfirms = this.getNumber(maxConfirms, 9999999);
+  minUnspentSize = this.getNumber(minUnspentSize);
 
   return this.wallet.unspents({minConfirms: minConfirms, minSize: minUnspentSize})
   .then(function(unspents) {

--- a/src/help/bitgod
+++ b/src/help/bitgod
@@ -20,8 +20,8 @@ listtransactions ( "account" count from minHeight decryptTravelInfo ))
 listunspent ( minconf maxconf addresses ignoreConfirmsForChange minUnspentSize )
 lock
 sendfrom "fromaccount" "tobitcoinaddress" amount ( minconf "comment" )
-sendmany "fromaccount" <recipients> ( minconf "comment" instant "sequenceId" minUnspentSize )
-sendmanyextended "fromaccount" <recipients> ( minconf "comment" instant "sequenceId" minUnspentSize )
+sendmany "fromaccount" <recipients> ( minconf "comment" instant "sequenceId" minUnspentSize enforceMinConfirmsForChange )
+sendmanyextended "fromaccount" <recipients> ( minconf "comment" instant "sequenceId" minUnspentSize enforceMinConfirmsForChange )
 sendtoaddress "bitcoinaddress" amount ( "comment" "comment-to" instant sequenceId minUnspentSize )
 sendtravelinfo "txid" <travelinfo>
 session

--- a/src/help/sendmany
+++ b/src/help/sendmany
@@ -1,4 +1,4 @@
-sendmany "fromaccount" <recipients> ( minconf "comment" instant "sequenceId" minUnspentSize )
+sendmany "fromaccount" <recipients> ( minconf "comment" instant "sequenceId" minUnspentSize enforceMinConfirmsForChange )
 
 Send multiple times. Amounts are double-precision floating point numbers.
 
@@ -11,15 +11,16 @@ Arguments:
 2. "recipients"          (array or object, required)
          OBJECT FORM:    { "ADDRESS1": amount1, "ADDRESS2": amount2, ... }
          ARRAY FORM :    [ { "address": "ADDRESS1", "amount": amount1 }, { "address": "ADDRESS1", "amount": amount2, "travelInfo": {...} }, ... ]
-                         
-3. minconf                 (numeric, optional, default=1) Only use the balance confirmed at least this many times.
-4. "comment"             (string, optional) A comment
-5. "instant"             (boolean, optional, default=false) Send this transaction as BitGo Instant
-6. "sequenceId"          (string, optional) A client-provided sequence id, which must be unique within this wallet.
-7. minUnspentSize        (numeric, optional) minimum satoshi value to use when selecting unspents
+
+3. minConf                          (numeric, optional, default=1) Only use the balance confirmed at least this many times.
+4. "comment"                        (string, optional) A comment
+5. instant                          (boolean, optional, default=false) Send this transaction as BitGo Instant
+6. "sequenceId"                     (string, optional) A client-provided sequence id, which must be unique within this wallet.
+7. minUnspentSize                   (numeric, optional) minimum satoshi value to use when selecting unspents
+8. enforceMinConfirmsForChange      (boolean, optional, default=false) Require change unspents to adhere to minConf
 
 Result:
-"transactionid"          (string) The transaction id for the send. Only 1 transaction is created regardless of 
+"transactionid"          (string) The transaction id for the send. Only 1 transaction is created regardless of
                                     the number of addresses.
 
 Examples:

--- a/src/help/sendmanyextended
+++ b/src/help/sendmanyextended
@@ -1,4 +1,4 @@
-sendmanyextended "fromaccount" <recipients> ( minconf "comment" instant "sequenceId" minUnspentSize )
+sendmanyextended "fromaccount" <recipients> ( minconf "comment" instant "sequenceId" minUnspentSize enforceMinConfirmsForChange )
 
 (This call takes identical parameters to sendmany, but provides an extended JSON result)
 
@@ -9,16 +9,17 @@ more flexibly as an array of objects. The array form allows producing multiple o
 same destination address, as well as attaching Travel Rule information if desired.
 
 Arguments:
-1. "fromaccount"         (string, required) DEPRECATED. The account to send the funds from. Should be "" for the default account
-2. "recipients"          (array or object, required)
-         OBJECT FORM:    { "ADDRESS1": amount1, "ADDRESS2": amount2, ... }
-         ARRAY FORM :    [ { "address": "ADDRESS1", "amount": amount1 }, { "address": "ADDRESS1", "amount": amount2, "travelInfo": {...} }, ... ]
-                         
-3. minconf                 (numeric, optional, default=1) Only use the balance confirmed at least this many times.
-4. "comment"             (string, optional) A comment
-5. "instant"             (boolean, optional, default=false) Send this transaction as BitGo Instant
-6. "sequenceId"          (string, optional) A client-provided sequence id, which must be unique within this wallet.
-7. minUnspentSize        (numeric, optional) minimum satoshi value to use when selecting unspents
+1. "fromaccount"            (string, required) DEPRECATED. The account to send the funds from. Should be "" for the default account
+2. "recipients"             (array or object, required)
+         OBJECT FORM:       { "ADDRESS1": amount1, "ADDRESS2": amount2, ... }
+         ARRAY FORM :       [ { "address": "ADDRESS1", "amount": amount1 }, { "address": "ADDRESS1", "amount": amount2, "travelInfo": {...} }, ... ]
+
+3. minconf                  (numeric, optional, default=1) Only use the balance confirmed at least this many times.
+4. "comment"                (string, optional) A comment
+5. instant                  (boolean, optional, default=false) Send this transaction as BitGo Instant
+6. "sequenceId"             (string, optional) A client-provided sequence id, which must be unique within this wallet.
+7. minUnspentSize           (numeric, optional) minimum satoshi value to use when selecting unspents
+8. enforceMinConfirmsForChange    (boolean, optional, default=false) Require change unspents to adhere to minConf
 
 Result:
 {


### PR DESCRIPTION
This was done in handleSendManyExtended previously but needs to be done in handleListUnspent. When getBalance is called with more than two params an error occurs stating minSize must be a number.

https://github.com/BitGo/bitgod/blob/638910a00c21a0ca7e4018d09b3fcdb861c5f6da/src/bitgod.js#L750


