### PR TITLE
Fix log priorities

### DIFF
--- a/src/bitgod.js
+++ b/src/bitgod.js
@@ -22,9 +22,9 @@ var BitGoD = function () {
 
   // Set up logger
   var logLevels = {
-    debug: 0,
+    debug: 2,
     info: 1,
-    error: 2
+    error: 0
   };
 
   var logColors = {
@@ -41,10 +41,10 @@ var BitGoD = function () {
   });
   this.logger.add(winston.transports.Console, { level: 'info', timestamp: true, colorize: true });
 
-  console.log = this.logger.info;
-  console.info = this.logger.info;
-  console.warn = this.logger.error;
-  console.error = this.logger.error;
+  console.log = this.logger.info.bind(this.logger);
+  console.info = this.logger.info.bind(this.logger);
+  console.warn = this.logger.error.bind(this.logger);
+  console.error = this.logger.error.bind(this.logger);
 };
 
 BitGoD.prototype.setLoggingEnabled = function(loggingEnabled) {


### PR DESCRIPTION
Currently, we do not see any errors since the levels are declared in
reverse order.

From https://github.com/winstonjs/winston/tree/2.3.1#logging

> Logging levels in winston conform to the severity ordering specified
> by RFC5424: severity of all levels is assumed to be numerically
> ascending from most important to least important.

Also bind methods to their host object.