### PR TITLE
BG-6651 Remove extraneous zero parameter

### DIFF
--- a/src/bitgod.js
+++ b/src/bitgod.js
@@ -708,7 +708,7 @@ BitGoD.prototype.getBalance = function(minConfirms, minUnspentSize) {
   var self = this;
   return Q().then(function() {
     if (minConfirms >= 2) {
-      return self.getBalanceFromUnspents(minConfirms, 9999999, 0, true, minUnspentSize);
+      return self.getBalanceFromUnspents(minConfirms, 9999999, true, minUnspentSize);
     }
     return self.getWallet()
     .then(function(wallet) {


### PR DESCRIPTION
A customer told us yesterday that the getBalance call was not acting as it had previously. This commit removes an extraneous parameter that was being passed.