### PR TITLE
Pass the sequenceId through the sendMany call

### DIFF
--- a/src/bitgod.js
+++ b/src/bitgod.js
@@ -1450,7 +1450,8 @@ BitGoD.prototype.handleSendManyExtended = function(account, recipients, minConfi
       instant: !!instant,
       minUnspentSize: minUnspentSize,
       targetWalletUnspents: self.minUnspentsTarget,
-      keychain: self.getSigningKeychain()
+      keychain: self.getSigningKeychain(),
+      sequenceId: sequenceId
     });
   })
   .then(function(result) {


### PR DESCRIPTION
It turns out that the sequenceId parameter wan't being passed
through the sendMany (and sendManyExtended) calls - it looks to
have been dropped accidentally in a previous refactor.